### PR TITLE
feat: adicionar tratamento especializado de erros SpTrans

### DIFF
--- a/src/main/java/RadarSptrans/example/RadarSPT/application/service/SpTransApplicationService.java
+++ b/src/main/java/RadarSptrans/example/RadarSPT/application/service/SpTransApplicationService.java
@@ -1,5 +1,6 @@
 package RadarSptrans.example.RadarSPT.application.service;
 
+import RadarSptrans.example.RadarSPT.domain.exception.IndiceLinhaInvalidoException;
 import RadarSptrans.example.RadarSPT.domain.model.LinhaResponse;
 import RadarSptrans.example.RadarSPT.domain.model.PosicaoBusResponse;
 import RadarSptrans.example.RadarSPT.domain.port.in.BuscarPosicaoPorCodigoUseCase;
@@ -26,7 +27,7 @@ public class SpTransApplicationService implements BuscarPosicaoPorCodigoUseCase,
         String sessionCookie = autenticacaoPort.autenticar();
         List<LinhaResponse> linhas = spTransDadosPort.buscarLinha(termosBusca, sessionCookie);
         if (indice < 1 || indice > linhas.size()) {
-            throw new IllegalArgumentException("Índice inválido.");
+            throw new IndiceLinhaInvalidoException();
         }
         String codigoLinha = String.valueOf(linhas.get(indice - 1).getCl());
         return spTransDadosPort.buscarPosicaoLinha(codigoLinha, sessionCookie);

--- a/src/main/java/RadarSptrans/example/RadarSPT/domain/exception/AutenticacaoException.java
+++ b/src/main/java/RadarSptrans/example/RadarSPT/domain/exception/AutenticacaoException.java
@@ -1,0 +1,12 @@
+package RadarSptrans.example.RadarSPT.domain.exception;
+
+public class AutenticacaoException extends RuntimeException {
+
+    public AutenticacaoException() {
+        super("Falha ao autenticar com o serviço SPTrans.");
+    }
+
+    public AutenticacaoException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/RadarSptrans/example/RadarSPT/domain/exception/CookieSessaoNaoEncontradoException.java
+++ b/src/main/java/RadarSptrans/example/RadarSPT/domain/exception/CookieSessaoNaoEncontradoException.java
@@ -1,0 +1,12 @@
+package RadarSptrans.example.RadarSPT.domain.exception;
+
+public class CookieSessaoNaoEncontradoException extends RuntimeException {
+
+    public CookieSessaoNaoEncontradoException() {
+        super("Cookie de sessão não encontrado na resposta de autenticação.");
+    }
+
+    public CookieSessaoNaoEncontradoException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/RadarSptrans/example/RadarSPT/domain/exception/IndiceLinhaInvalidoException.java
+++ b/src/main/java/RadarSptrans/example/RadarSPT/domain/exception/IndiceLinhaInvalidoException.java
@@ -1,0 +1,12 @@
+package RadarSptrans.example.RadarSPT.domain.exception;
+
+public class IndiceLinhaInvalidoException extends RuntimeException {
+
+    public IndiceLinhaInvalidoException() {
+        super("Índice de linha informado é inválido.");
+    }
+
+    public IndiceLinhaInvalidoException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/in/rest/ApiErrorResponse.java
+++ b/src/main/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/in/rest/ApiErrorResponse.java
@@ -1,0 +1,4 @@
+package RadarSptrans.example.RadarSPT.infrastructure.adapter.in.rest;
+
+public record ApiErrorResponse(String code, String message) {
+}

--- a/src/main/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/in/rest/SpTransExceptionHandler.java
+++ b/src/main/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/in/rest/SpTransExceptionHandler.java
@@ -1,0 +1,36 @@
+package RadarSptrans.example.RadarSPT.infrastructure.adapter.in.rest;
+
+import RadarSptrans.example.RadarSPT.domain.exception.AutenticacaoException;
+import RadarSptrans.example.RadarSPT.domain.exception.CookieSessaoNaoEncontradoException;
+import RadarSptrans.example.RadarSPT.domain.exception.IndiceLinhaInvalidoException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class SpTransExceptionHandler {
+
+    private static final String CODE_INDICE_INVALIDO = "LINHA_INDICE_INVALIDO";
+    private static final String CODE_AUTENTICACAO_FALHOU = "AUTENTICACAO_FALHOU";
+    private static final String CODE_COOKIE_NAO_ENCONTRADO = "COOKIE_SESSAO_NAO_ENCONTRADO";
+
+    @ExceptionHandler(IndiceLinhaInvalidoException.class)
+    public ResponseEntity<ApiErrorResponse> handleIndiceLinhaInvalido(IndiceLinhaInvalidoException exception) {
+        return buildResponse(HttpStatus.BAD_REQUEST, CODE_INDICE_INVALIDO, exception.getMessage());
+    }
+
+    @ExceptionHandler(AutenticacaoException.class)
+    public ResponseEntity<ApiErrorResponse> handleAutenticacao(AutenticacaoException exception) {
+        return buildResponse(HttpStatus.UNAUTHORIZED, CODE_AUTENTICACAO_FALHOU, exception.getMessage());
+    }
+
+    @ExceptionHandler(CookieSessaoNaoEncontradoException.class)
+    public ResponseEntity<ApiErrorResponse> handleCookieNaoEncontrado(CookieSessaoNaoEncontradoException exception) {
+        return buildResponse(HttpStatus.UNAUTHORIZED, CODE_COOKIE_NAO_ENCONTRADO, exception.getMessage());
+    }
+
+    private ResponseEntity<ApiErrorResponse> buildResponse(HttpStatus status, String code, String message) {
+        return ResponseEntity.status(status).body(new ApiErrorResponse(code, message));
+    }
+}

--- a/src/main/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/out/sptrans/SpTransAuthClientAdapter.java
+++ b/src/main/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/out/sptrans/SpTransAuthClientAdapter.java
@@ -1,8 +1,11 @@
 package RadarSptrans.example.RadarSPT.infrastructure.adapter.out.sptrans;
 
+import RadarSptrans.example.RadarSPT.domain.exception.AutenticacaoException;
+import RadarSptrans.example.RadarSPT.domain.exception.CookieSessaoNaoEncontradoException;
 import RadarSptrans.example.RadarSPT.domain.port.out.AutenticacaoPort;
 import feign.Response;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;
@@ -22,13 +25,13 @@ public class SpTransAuthClientAdapter implements AutenticacaoPort {
     @Override
     public String autenticar() {
         Response authResponse = authClient.autenticar(apiToken);
-        if (authResponse.status() == 200) {
+        if (authResponse.status() == HttpStatus.OK.value()) {
             Collection<String> cookies = authResponse.headers().get("Set-Cookie");
             if (cookies != null && !cookies.isEmpty()) {
                 return cookies.iterator().next();
             }
-            throw new RuntimeException("Falha ao capturar o cookie de sessão.");
+            throw new CookieSessaoNaoEncontradoException();
         }
-        throw new RuntimeException("Autenticação falhou.");
+        throw new AutenticacaoException();
     }
 }

--- a/src/test/java/RadarSptrans/example/RadarSPT/application/service/SpTransApplicationServiceTest.java
+++ b/src/test/java/RadarSptrans/example/RadarSPT/application/service/SpTransApplicationServiceTest.java
@@ -1,0 +1,41 @@
+package RadarSptrans.example.RadarSPT.application.service;
+
+import RadarSptrans.example.RadarSPT.domain.exception.IndiceLinhaInvalidoException;
+import RadarSptrans.example.RadarSPT.domain.model.LinhaResponse;
+import RadarSptrans.example.RadarSPT.domain.port.out.AutenticacaoPort;
+import RadarSptrans.example.RadarSPT.domain.port.out.SpTransDadosPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SpTransApplicationServiceTest {
+
+    private AutenticacaoPort autenticacaoPort;
+    private SpTransDadosPort spTransDadosPort;
+    private SpTransApplicationService service;
+
+    @BeforeEach
+    void setUp() {
+        autenticacaoPort = mock(AutenticacaoPort.class);
+        spTransDadosPort = mock(SpTransDadosPort.class);
+        service = new SpTransApplicationService(autenticacaoPort, spTransDadosPort);
+    }
+
+    @Test
+    void deveLancarIndiceLinhaInvalidoQuandoIndiceForaDoIntervalo() {
+        when(autenticacaoPort.autenticar()).thenReturn("cookie");
+        when(spTransDadosPort.buscarLinha("terminal", "cookie"))
+                .thenReturn(List.of(new LinhaResponse(1, true, "8000", 1, 1, "Terminal", "Term.")));
+
+        IndiceLinhaInvalidoException exception = assertThrows(IndiceLinhaInvalidoException.class,
+                () -> service.buscarPorTermo("terminal", 0));
+
+        assertEquals("Índice de linha informado é inválido.", exception.getMessage());
+    }
+}

--- a/src/test/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/in/rest/SpTransExceptionHandlerTest.java
+++ b/src/test/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/in/rest/SpTransExceptionHandlerTest.java
@@ -1,0 +1,48 @@
+package RadarSptrans.example.RadarSPT.infrastructure.adapter.in.rest;
+
+import RadarSptrans.example.RadarSPT.domain.exception.AutenticacaoException;
+import RadarSptrans.example.RadarSPT.domain.exception.CookieSessaoNaoEncontradoException;
+import RadarSptrans.example.RadarSPT.domain.exception.IndiceLinhaInvalidoException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SpTransExceptionHandlerTest {
+
+    private SpTransExceptionHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new SpTransExceptionHandler();
+    }
+
+    @Test
+    void deveMapearIndiceLinhaInvalidoParaBadRequest() {
+        ResponseEntity<ApiErrorResponse> response = handler.handleIndiceLinhaInvalido(new IndiceLinhaInvalidoException());
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("LINHA_INDICE_INVALIDO", response.getBody().code());
+        assertEquals("Índice de linha informado é inválido.", response.getBody().message());
+    }
+
+    @Test
+    void deveMapearAutenticacaoParaUnauthorized() {
+        ResponseEntity<ApiErrorResponse> response = handler.handleAutenticacao(new AutenticacaoException());
+
+        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+        assertEquals("AUTENTICACAO_FALHOU", response.getBody().code());
+        assertEquals("Falha ao autenticar com o serviço SPTrans.", response.getBody().message());
+    }
+
+    @Test
+    void deveMapearCookieNaoEncontradoParaUnauthorized() {
+        ResponseEntity<ApiErrorResponse> response = handler.handleCookieNaoEncontrado(new CookieSessaoNaoEncontradoException());
+
+        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+        assertEquals("COOKIE_SESSAO_NAO_ENCONTRADO", response.getBody().code());
+        assertEquals("Cookie de sessão não encontrado na resposta de autenticação.", response.getBody().message());
+    }
+}

--- a/src/test/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/out/sptrans/SpTransAuthClientAdapterTest.java
+++ b/src/test/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/out/sptrans/SpTransAuthClientAdapterTest.java
@@ -1,0 +1,72 @@
+package RadarSptrans.example.RadarSPT.infrastructure.adapter.out.sptrans;
+
+import RadarSptrans.example.RadarSPT.domain.exception.AutenticacaoException;
+import RadarSptrans.example.RadarSPT.domain.exception.CookieSessaoNaoEncontradoException;
+import feign.Request;
+import feign.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SpTransAuthClientAdapterTest {
+
+    private SpTransAuthClient authClient;
+    private SpTransAuthClientAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        authClient = mock(SpTransAuthClient.class);
+        adapter = new SpTransAuthClientAdapter(authClient, "token");
+    }
+
+    @Test
+    void deveRetornarCookieQuandoAutenticacaoSucesso() {
+        Response response = criarResposta(200, Map.of("Set-Cookie", List.of("cookie=valor")));
+        when(authClient.autenticar("token")).thenReturn(response);
+
+        String cookie = adapter.autenticar();
+
+        assertEquals("cookie=valor", cookie);
+    }
+
+    @Test
+    void deveLancarExcecaoQuandoCookieNaoEncontrado() {
+        Response response = criarResposta(200, Map.of());
+        when(authClient.autenticar("token")).thenReturn(response);
+
+        CookieSessaoNaoEncontradoException exception = assertThrows(CookieSessaoNaoEncontradoException.class, adapter::autenticar);
+        assertEquals("Cookie de sessão não encontrado na resposta de autenticação.", exception.getMessage());
+    }
+
+    @Test
+    void deveLancarExcecaoDeAutenticacaoQuandoStatusNaoSucesso() {
+        Response response = criarResposta(401, Map.of());
+        when(authClient.autenticar("token")).thenReturn(response);
+
+        AutenticacaoException exception = assertThrows(AutenticacaoException.class, adapter::autenticar);
+        assertEquals("Falha ao autenticar com o serviço SPTrans.", exception.getMessage());
+    }
+
+    private Response criarResposta(int status, Map<String, Collection<String>> headers) {
+        Request request = Request.create(Request.HttpMethod.POST,
+                "https://api.olhovivo.sptrans.com.br/v2.1/Login/Autenticar",
+                Map.of(),
+                null,
+                StandardCharsets.UTF_8,
+                null);
+        return Response.builder()
+                .status(status)
+                .headers(headers)
+                .request(request)
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- adicionar exceções de domínio dedicadas para autenticação, cookie de sessão ausente e índice de linha inválido
- aplicar as novas exceções no serviço de aplicação e no adaptador de autenticação da SPTrans
- disponibilizar handler REST que converte as exceções em respostas 400/401 com payload padronizado e cobrir os fluxos com testes unitários

## Testing
- mvn test *(falha: impossibilidade de baixar dependências do Maven Central - HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a52f80408327aa1b46d3e0a2a74a