### PR TITLE
Fix controller unit test imports and dependencies

### DIFF
--- a/src/test/java/RadarSptrans/example/RadarSPT/resource/SpTransControllerTest.java
+++ b/src/test/java/RadarSptrans/example/RadarSPT/resource/SpTransControllerTest.java
@@ -1,141 +1,76 @@
 package RadarSptrans.example.RadarSPT.resource;
 
-import RadarSptrans.example.RadarSPT.client.SpTransAuthClient;
-import RadarSptrans.example.RadarSPT.client.SpTransClient;
-import RadarSptrans.example.RadarSPT.response.LinhaResponse;
-import RadarSptrans.example.RadarSPT.response.PosicaoBus;
-import RadarSptrans.example.RadarSPT.response.PosicaoBusResponse;
-import feign.Request;
-import feign.Response;
-import org.junit.jupiter.api.BeforeEach;
+import RadarSptrans.example.RadarSPT.domain.exception.AutenticacaoException;
+import RadarSptrans.example.RadarSPT.domain.exception.IndiceLinhaInvalidoException;
+import RadarSptrans.example.RadarSPT.domain.model.PosicaoBus;
+import RadarSptrans.example.RadarSPT.domain.model.PosicaoBusResponse;
+import RadarSptrans.example.RadarSPT.domain.port.in.BuscarPosicaoPorCodigoUseCase;
+import RadarSptrans.example.RadarSPT.domain.port.in.BuscarPosicaoPorTermoUseCase;
+import RadarSptrans.example.RadarSPT.infrastructure.adapter.in.rest.SpTransController;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class SpTransControllerTest {
 
     @Mock
-    private SpTransAuthClient authClient;
+    private BuscarPosicaoPorTermoUseCase buscarPosicaoPorTermoUseCase;
 
     @Mock
-    private SpTransClient spTransClient;
+    private BuscarPosicaoPorCodigoUseCase buscarPosicaoPorCodigoUseCase;
 
     @InjectMocks
     private SpTransController controller;
 
-    private Response authSuccessResponseWithCookie;
-    private Response authSuccessResponseWithoutCookie;
-    private Response authFailureResponse;
-
-    @BeforeEach
-    void setUp() {
-        Request request = Request.create(
-                Request.HttpMethod.POST,
-                "/Autenticar",
-                Collections.emptyMap(),
-                null,
-                StandardCharsets.UTF_8,
-                null
+    @Test
+    void buscarLinhasRetornaRespostaDoCasoDeUso() {
+        PosicaoBusResponse expectedResponse = new PosicaoBusResponse(
+                "10:00",
+                List.of(new PosicaoBus("1234", true, null, -23.0, -46.0, null, null))
         );
+        when(buscarPosicaoPorTermoUseCase.buscarPorTermo("term", 1)).thenReturn(expectedResponse);
 
-        authSuccessResponseWithCookie = Response.builder()
-                .status(200)
-                .reason("OK")
-                .request(request)
-                .headers(Map.of("Set-Cookie", List.of("SESSION=123")))
-                .build();
+        PosicaoBusResponse resultado = controller.buscarLinhas("term", 1);
 
-        authSuccessResponseWithoutCookie = Response.builder()
-                .status(200)
-                .reason("OK")
-                .request(request)
-                .headers(Collections.emptyMap())
-                .build();
-
-        authFailureResponse = Response.builder()
-                .status(401)
-                .reason("Unauthorized")
-                .request(request)
-                .headers(Collections.emptyMap())
-                .build();
+        assertEquals(expectedResponse, resultado);
+        verify(buscarPosicaoPorTermoUseCase).buscarPorTermo("term", 1);
     }
 
     @Test
-    void buscarLinhasReturnsBusPositionWhenIndexIsValid() {
-        List<LinhaResponse> linhas = List.of(new LinhaResponse(123, false, "8000", 1, 1, "Terminal", "Bairro"));
-        PosicaoBusResponse expectedResponse = new PosicaoBusResponse("10:00", List.of(new PosicaoBus("bus", true, null, -23.0, -46.0, null, null)));
+    void buscarLinhasPropagaExcecoesDoCasoDeUso() {
+        when(buscarPosicaoPorTermoUseCase.buscarPorTermo("term", 2)).thenThrow(new IndiceLinhaInvalidoException());
 
-        when(authClient.autenticar(org.mockito.ArgumentMatchers.anyString())).thenReturn(authSuccessResponseWithCookie);
-        when(spTransClient.buscarLinha("term", "SESSION=123")).thenReturn(linhas);
-        when(spTransClient.localBus("123", "SESSION=123")).thenReturn(expectedResponse);
-
-        PosicaoBusResponse result = controller.buscarLinhas("term", 1);
-
-        assertEquals(expectedResponse, result);
+        assertThrows(IndiceLinhaInvalidoException.class, () -> controller.buscarLinhas("term", 2));
     }
 
     @Test
-    void buscarLinhasThrowsExceptionWhenIndexIsInvalid() {
-        List<LinhaResponse> linhas = List.of(new LinhaResponse(123, false, "8000", 1, 1, "Terminal", "Bairro"));
+    void localBusRetornaRespostaDoCasoDeUso() {
+        PosicaoBusResponse expectedResponse = new PosicaoBusResponse(
+                "11:00",
+                List.of(new PosicaoBus("4321", false, null, -22.0, -45.0, null, null))
+        );
+        when(buscarPosicaoPorCodigoUseCase.buscarPorCodigo("123")).thenReturn(expectedResponse);
 
-        when(authClient.autenticar(org.mockito.ArgumentMatchers.anyString())).thenReturn(authSuccessResponseWithCookie);
-        when(spTransClient.buscarLinha("term", "SESSION=123")).thenReturn(linhas);
+        PosicaoBusResponse resultado = controller.localBus("123");
 
-        assertThrows(IllegalArgumentException.class, () -> controller.buscarLinhas("term", 2));
+        assertEquals(expectedResponse, resultado);
+        verify(buscarPosicaoPorCodigoUseCase).buscarPorCodigo("123");
     }
 
     @Test
-    void buscarLinhasThrowsExceptionWhenCookieMissing() {
-        when(authClient.autenticar(org.mockito.ArgumentMatchers.anyString())).thenReturn(authSuccessResponseWithoutCookie);
+    void localBusPropagaExcecoesDoCasoDeUso() {
+        when(buscarPosicaoPorCodigoUseCase.buscarPorCodigo("123")).thenThrow(new AutenticacaoException());
 
-        RuntimeException exception = assertThrows(RuntimeException.class, () -> controller.buscarLinhas("term", 1));
-        assertTrue(exception.getMessage().contains("Falha ao capturar o cookie"));
-    }
-
-    @Test
-    void buscarLinhasThrowsExceptionWhenAuthenticationFails() {
-        when(authClient.autenticar(org.mockito.ArgumentMatchers.anyString())).thenReturn(authFailureResponse);
-
-        RuntimeException exception = assertThrows(RuntimeException.class, () -> controller.buscarLinhas("term", 1));
-        assertTrue(exception.getMessage().contains("Autenticação falhou"));
-    }
-
-    @Test
-    void localBusReturnsBusPositionWhenAuthenticationSucceeds() {
-        PosicaoBusResponse expectedResponse = new PosicaoBusResponse("10:00", List.of(new PosicaoBus("bus", true, null, -23.0, -46.0, null, null)));
-
-        when(authClient.autenticar(org.mockito.ArgumentMatchers.anyString())).thenReturn(authSuccessResponseWithCookie);
-        when(spTransClient.localBus("123", "SESSION=123")).thenReturn(expectedResponse);
-
-        PosicaoBusResponse result = controller.localBus("123");
-
-        assertEquals(expectedResponse, result);
-    }
-
-    @Test
-    void localBusThrowsExceptionWhenCookieMissing() {
-        when(authClient.autenticar(org.mockito.ArgumentMatchers.anyString())).thenReturn(authSuccessResponseWithoutCookie);
-
-        RuntimeException exception = assertThrows(RuntimeException.class, () -> controller.localBus("123"));
-        assertTrue(exception.getMessage().contains("Falha ao capturar o cookie"));
-    }
-
-    @Test
-    void localBusThrowsExceptionWhenAuthenticationFails() {
-        when(authClient.autenticar(org.mockito.ArgumentMatchers.anyString())).thenReturn(authFailureResponse);
-
-        RuntimeException exception = assertThrows(RuntimeException.class, () -> controller.localBus("123"));
-        assertTrue(exception.getMessage().contains("Autenticação falhou"));
+        assertThrows(AutenticacaoException.class, () -> controller.localBus("123"));
     }
 }


### PR DESCRIPTION
## Summary
- update `SpTransControllerTest` to mock the controller's use case dependencies instead of nonexistent client classes
- align imports with the production package structure and simplify assertions to verify delegation behavior

## Testing
- `./mvnw -q test` *(fails: Maven wrapper could not download Maven due to network restrictions in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d608668aa48327855bc3fff74d8438