### PR TITLE
Configure CORS allowed origins via property

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ O **RadarSptrans** é uma API Spring Boot que consulta o serviço público Olho 
   - `SpTransAuthClientAdapter` realiza a autenticação no serviço Olho Vivo e captura o cookie de sessão.
   - `SpTransClientAdapter` consome os endpoints de busca e posição através do OpenFeign.
   - `SpTransController` expõe os endpoints REST `/api/sptrans`.
-- **Configuração adicional**: `WebConfig` habilita CORS para o front-end.
+- **Configuração adicional**: `WebConfig` habilita CORS para o front-end com base na propriedade `sptrans.cors.allowed-origins`.
 
 ## ✅ Pré-requisitos
 - **Java 17**
@@ -23,7 +23,11 @@ O **RadarSptrans** é uma API Spring Boot que consulta o serviço público Olho 
    ```bash
    export SPRING_APPLICATION_JSON='{"sptrans":{"api":{"token":"SEU_TOKEN_AQUI"}}}'
    ```
-3. (Opcional) Ajuste `WebConfig` caso deseje liberar CORS para outra origem.
+3. Ajuste as origens permitidas para CORS, se necessário. Por padrão, `sptrans.cors.allowed-origins` aceita `http://localhost:5500` e `http://127.0.0.1:5500`. Para alterar via variável de ambiente, exporte:
+   ```bash
+   export SPTRANS_CORS_ALLOWED_ORIGINS="http://localhost:5500,http://127.0.0.1:5500"
+   ```
+   Também é possível usar `SPRING_APPLICATION_JSON` conforme o exemplo anterior.
 
 > ⚠️ O token presente no repositório é apenas ilustrativo. Gere seu próprio token no [portal da SPTrans](http://www.sptrans.com.br/desenvolvedores/).
 

--- a/src/main/java/RadarSptrans/example/RadarSPT/config/WebConfig.java
+++ b/src/main/java/RadarSptrans/example/RadarSPT/config/WebConfig.java
@@ -1,16 +1,28 @@
 package RadarSptrans.example.RadarSPT.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
+
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    private final String[] allowedOrigins;
+
+    public WebConfig(@Value("${sptrans.cors.allowed-origins:http://localhost:5500,http://127.0.0.1:5500}") List<String> allowedOrigins) {
+        this.allowedOrigins = allowedOrigins.stream()
+                .map(String::trim)
+                .filter(origin -> !origin.isEmpty())
+                .toArray(String[]::new);
+    }
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://127.0.0.1:5500")
+                .allowedOrigins(allowedOrigins)
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 spring.application.name=RadarSPT
 sptrans.api.token=0b2b7996a6aae16fba7fd5386b3c630d5efc26cb0f9373e1e21aebe89ca60963
+sptrans.cors.allowed-origins=http://localhost:5500,http://127.0.0.1:5500

--- a/src/test/java/RadarSptrans/example/RadarSPT/config/WebConfigCorsTest.java
+++ b/src/test/java/RadarSptrans/example/RadarSPT/config/WebConfigCorsTest.java
@@ -1,0 +1,74 @@
+package RadarSptrans.example.RadarSPT.config;
+
+import RadarSptrans.example.RadarSPT.domain.model.PosicaoBusResponse;
+import RadarSptrans.example.RadarSPT.domain.port.in.BuscarPosicaoPorCodigoUseCase;
+import RadarSptrans.example.RadarSPT.domain.port.in.BuscarPosicaoPorTermoUseCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class WebConfigCorsTest {
+
+    private static final List<String> ALLOWED_ORIGINS = List.of(
+            "http://localhost:5500",
+            "http://127.0.0.1:5500"
+    );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private BuscarPosicaoPorTermoUseCase buscarPosicaoPorTermoUseCase;
+
+    @MockBean
+    private BuscarPosicaoPorCodigoUseCase buscarPosicaoPorCodigoUseCase;
+
+    @BeforeEach
+    void setUpMocks() {
+        when(buscarPosicaoPorTermoUseCase.buscarPorTermo(anyString(), anyInt()))
+                .thenReturn(new PosicaoBusResponse());
+        when(buscarPosicaoPorCodigoUseCase.buscarPorCodigo(anyString()))
+                .thenReturn(new PosicaoBusResponse());
+    }
+
+    @Test
+    void shouldAllowConfiguredOriginsOnPreflightRequests() throws Exception {
+        for (String origin : ALLOWED_ORIGINS) {
+            mockMvc.perform(options("/api/sptrans/buscar")
+                            .header("Origin", origin)
+                            .header("Access-Control-Request-Method", "GET"))
+                    .andExpect(status().isOk())
+                    .andExpect(header().string("Access-Control-Allow-Origin", origin));
+        }
+    }
+
+    @Test
+    void shouldReturnCorsHeaderForActualRequestsFromAllowedOrigins() throws Exception {
+        for (String origin : ALLOWED_ORIGINS) {
+            mockMvc.perform(get("/api/sptrans/buscar")
+                            .header("Origin", origin)
+                            .param("termosBusca", "8000")
+                            .param("indice", "0")
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(header().string("Access-Control-Allow-Origin", origin));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow configuring CORS origins through the `sptrans.cors.allowed-origins` property with a secure default
- document how to override the allowed origins via environment variables
- add MockMvc tests to ensure both default origins are accepted

## Testing
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68d6da1d41bc8327b04e180cde9a9a4b