### PR TITLE
Sanitize SPTrans auth cookie before reuse

### DIFF
--- a/src/main/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/out/sptrans/SpTransAuthClientAdapter.java
+++ b/src/main/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/out/sptrans/SpTransAuthClientAdapter.java
@@ -8,7 +8,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
+import java.net.HttpCookie;
 import java.util.Collection;
+import java.util.List;
 
 @Component
 public class SpTransAuthClientAdapter implements AutenticacaoPort {
@@ -28,10 +30,25 @@ public class SpTransAuthClientAdapter implements AutenticacaoPort {
         if (authResponse.status() == HttpStatus.OK.value()) {
             Collection<String> cookies = authResponse.headers().get("Set-Cookie");
             if (cookies != null && !cookies.isEmpty()) {
-                return cookies.iterator().next();
+                String rawCookie = cookies.iterator().next();
+                return sanitizeCookie(rawCookie);
             }
             throw new CookieSessaoNaoEncontradoException();
         }
         throw new AutenticacaoException();
+    }
+
+    private String sanitizeCookie(String rawCookie) {
+        try {
+            List<HttpCookie> parsedCookies = HttpCookie.parse(rawCookie);
+            if (!parsedCookies.isEmpty()) {
+                HttpCookie cookie = parsedCookies.get(0);
+                return cookie.getName() + "=" + cookie.getValue();
+            }
+        } catch (IllegalArgumentException ignored) {
+            // Caso não seja possível realizar o parse, utiliza fallback manual abaixo.
+        }
+        int delimiterIndex = rawCookie.indexOf(';');
+        return delimiterIndex >= 0 ? rawCookie.substring(0, delimiterIndex) : rawCookie;
     }
 }

--- a/src/test/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/out/sptrans/SpTransAuthClientAdapterTest.java
+++ b/src/test/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/out/sptrans/SpTransAuthClientAdapterTest.java
@@ -2,6 +2,7 @@ package RadarSptrans.example.RadarSPT.infrastructure.adapter.out.sptrans;
 
 import RadarSptrans.example.RadarSPT.domain.exception.AutenticacaoException;
 import RadarSptrans.example.RadarSPT.domain.exception.CookieSessaoNaoEncontradoException;
+import RadarSptrans.example.RadarSPT.domain.model.LinhaResponse;
 import feign.Request;
 import feign.Response;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,6 +16,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class SpTransAuthClientAdapterTest {
@@ -29,13 +31,23 @@ class SpTransAuthClientAdapterTest {
     }
 
     @Test
-    void deveRetornarCookieQuandoAutenticacaoSucesso() {
-        Response response = criarResposta(200, Map.of("Set-Cookie", List.of("cookie=valor")));
+    void deveRetornarCookieSanitizadoQuandoAutenticacaoSucesso() {
+        Response response = criarResposta(200, Map.of("Set-Cookie", List.of("cookie=valor; Path=/; HttpOnly")));
         when(authClient.autenticar("token")).thenReturn(response);
 
         String cookie = adapter.autenticar();
 
         assertEquals("cookie=valor", cookie);
+    }
+
+    @Test
+    void deveManterCookieSemAtributosQuandoAutenticacaoSucesso() {
+        Response response = criarResposta(200, Map.of("Set-Cookie", List.of("session=abc123")));
+        when(authClient.autenticar("token")).thenReturn(response);
+
+        String cookie = adapter.autenticar();
+
+        assertEquals("session=abc123", cookie);
     }
 
     @Test
@@ -54,6 +66,19 @@ class SpTransAuthClientAdapterTest {
 
         AutenticacaoException exception = assertThrows(AutenticacaoException.class, adapter::autenticar);
         assertEquals("Falha ao autenticar com o serviço SPTrans.", exception.getMessage());
+    }
+
+    @Test
+    void deveEnviarCookieSanitizadoAoClienteFeign() {
+        SpTransClient spTransClient = mock(SpTransClient.class);
+        SpTransClientAdapter spTransClientAdapter = new SpTransClientAdapter(spTransClient);
+        List<LinhaResponse> respostaEsperada = List.of();
+        when(spTransClient.buscarLinha("busca", "cookie=valor")).thenReturn(respostaEsperada);
+
+        List<LinhaResponse> resposta = spTransClientAdapter.buscarLinha("busca", "cookie=valor");
+
+        assertEquals(respostaEsperada, resposta);
+        verify(spTransClient).buscarLinha("busca", "cookie=valor");
     }
 
     private Response criarResposta(int status, Map<String, Collection<String>> headers) {


### PR DESCRIPTION
## Summary
- sanitize the Set-Cookie returned by the authentication client to only include the name/value pair
- add unit coverage for sanitized cookies and ensure the Feign client receives the expected header value

## Testing
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68d6da1e5cb883279dd46b79531f0b9c