### PR TITLE
Sanitize SPTrans session cookie before reuse

### DIFF
--- a/src/main/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/out/sptrans/CookieSanitizer.java
+++ b/src/main/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/out/sptrans/CookieSanitizer.java
@@ -1,0 +1,37 @@
+package RadarSptrans.example.RadarSPT.infrastructure.adapter.out.sptrans;
+
+import java.net.HttpCookie;
+import java.util.List;
+
+final class CookieSanitizer {
+
+    private CookieSanitizer() {
+    }
+
+    static String sanitize(String rawCookie) {
+        if (rawCookie == null) {
+            return "";
+        }
+
+        String trimmedCookie = rawCookie.trim();
+        if (trimmedCookie.isEmpty()) {
+            return "";
+        }
+
+        try {
+            List<HttpCookie> parsedCookies = HttpCookie.parse(trimmedCookie);
+            if (!parsedCookies.isEmpty()) {
+                HttpCookie cookie = parsedCookies.get(0);
+                if (!cookie.getName().isEmpty()) {
+                    return cookie.getName() + "=" + cookie.getValue();
+                }
+            }
+        } catch (IllegalArgumentException ignored) {
+            // Fallback to manual sanitization below.
+        }
+
+        int delimiterIndex = trimmedCookie.indexOf(';');
+        String sanitizedCookie = delimiterIndex >= 0 ? trimmedCookie.substring(0, delimiterIndex) : trimmedCookie;
+        return sanitizedCookie.trim();
+    }
+}

--- a/src/main/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/out/sptrans/SpTransAuthClientAdapter.java
+++ b/src/main/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/out/sptrans/SpTransAuthClientAdapter.java
@@ -28,7 +28,11 @@ public class SpTransAuthClientAdapter implements AutenticacaoPort {
         if (authResponse.status() == HttpStatus.OK.value()) {
             Collection<String> cookies = authResponse.headers().get("Set-Cookie");
             if (cookies != null && !cookies.isEmpty()) {
-                return cookies.iterator().next();
+                String rawCookie = cookies.iterator().next();
+                String sanitizedCookie = CookieSanitizer.sanitize(rawCookie);
+                if (!sanitizedCookie.isEmpty()) {
+                    return sanitizedCookie;
+                }
             }
             throw new CookieSessaoNaoEncontradoException();
         }

--- a/src/main/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/out/sptrans/SpTransClientAdapter.java
+++ b/src/main/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/out/sptrans/SpTransClientAdapter.java
@@ -18,11 +18,11 @@ public class SpTransClientAdapter implements SpTransDadosPort {
 
     @Override
     public List<LinhaResponse> buscarLinha(String termosBusca, String sessionCookie) {
-        return spTransClient.buscarLinha(termosBusca, sessionCookie);
+        return spTransClient.buscarLinha(termosBusca, CookieSanitizer.sanitize(sessionCookie));
     }
 
     @Override
     public PosicaoBusResponse buscarPosicaoLinha(String codigoLinha, String sessionCookie) {
-        return spTransClient.localBus(codigoLinha, sessionCookie);
+        return spTransClient.localBus(codigoLinha, CookieSanitizer.sanitize(sessionCookie));
     }
 }

--- a/src/test/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/out/sptrans/SpTransAuthClientAdapterTest.java
+++ b/src/test/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/out/sptrans/SpTransAuthClientAdapterTest.java
@@ -29,8 +29,18 @@ class SpTransAuthClientAdapterTest {
     }
 
     @Test
-    void deveRetornarCookieQuandoAutenticacaoSucesso() {
-        Response response = criarResposta(200, Map.of("Set-Cookie", List.of("cookie=valor")));
+    void deveRetornarCookieSaneadoQuandoAutenticacaoSucesso() {
+        Response response = criarResposta(200, Map.of("Set-Cookie", List.of("cookie=valor; Path=/; HttpOnly")));
+        when(authClient.autenticar("token")).thenReturn(response);
+
+        String cookie = adapter.autenticar();
+
+        assertEquals("cookie=valor", cookie);
+    }
+
+    @Test
+    void deveRetornarCookieMesmoQuandoFormatoNaoEhReconhecidoPeloParser() {
+        Response response = criarResposta(200, Map.of("Set-Cookie", List.of("cookie=valor;secure")));
         when(authClient.autenticar("token")).thenReturn(response);
 
         String cookie = adapter.autenticar();

--- a/src/test/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/out/sptrans/SpTransClientAdapterTest.java
+++ b/src/test/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/out/sptrans/SpTransClientAdapterTest.java
@@ -1,0 +1,48 @@
+package RadarSptrans.example.RadarSPT.infrastructure.adapter.out.sptrans;
+
+import RadarSptrans.example.RadarSPT.domain.model.LinhaResponse;
+import RadarSptrans.example.RadarSPT.domain.model.PosicaoBusResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SpTransClientAdapterTest {
+
+    private SpTransClient spTransClient;
+    private SpTransClientAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        spTransClient = mock(SpTransClient.class);
+        adapter = new SpTransClientAdapter(spTransClient);
+    }
+
+    @Test
+    void deveEnviarCookieSaneadoNaBuscaDeLinhas() {
+        List<LinhaResponse> expected = List.of();
+        when(spTransClient.buscarLinha(eq("linha"), eq("cookie=valor"))).thenReturn(expected);
+
+        List<LinhaResponse> result = adapter.buscarLinha("linha", "cookie=valor; Path=/; HttpOnly");
+
+        assertSame(expected, result);
+        verify(spTransClient).buscarLinha("linha", "cookie=valor");
+    }
+
+    @Test
+    void deveEnviarCookieSaneadoNaBuscaDePosicao() {
+        PosicaoBusResponse expected = new PosicaoBusResponse();
+        when(spTransClient.localBus(eq("123"), eq("cookie=valor"))).thenReturn(expected);
+
+        PosicaoBusResponse result = adapter.buscarPosicaoLinha("123", "cookie=valor; Secure");
+
+        assertSame(expected, result);
+        verify(spTransClient).localBus("123", "cookie=valor");
+    }
+}


### PR DESCRIPTION
## Summary
- sanitize the authentication Set-Cookie header to extract only the name=value pair
- reuse the sanitized cookie when invoking SPTrans client endpoints
- add unit tests to cover cookie sanitization and header forwarding

## Testing
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68dd624a5d2c83279981da2a8bf61949