### PR TITLE
Make CORS allowed origins configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ O **RadarSptrans** é uma API Spring Boot que consulta o serviço público Olho 
    ```bash
    export SPRING_APPLICATION_JSON='{"sptrans":{"api":{"token":"SEU_TOKEN_AQUI"}}}'
    ```
-3. (Opcional) Ajuste `WebConfig` caso deseje liberar CORS para outra origem.
+3. Ajuste as origens permitidas configurando a propriedade `sptrans.cors.allowed-origins`. Por padrão ela já inclui `http://localhost:5500` e `http://127.0.0.1:5500`, mas você pode sobrescrevê-la no `application.properties` ou via variável de ambiente:
+   ```bash
+   export SPRING_APPLICATION_JSON='{"sptrans":{"cors":{"allowed-origins":"https://minhaapp.com,https://admin.minhaapp.com"}}}'
+   ```
+   > Use uma lista separada por vírgulas para definir todas as origens necessárias em ambientes de produção ou desenvolvimento.
 
 > ⚠️ O token presente no repositório é apenas ilustrativo. Gere seu próprio token no [portal da SPTrans](http://www.sptrans.com.br/desenvolvedores/).
 

--- a/src/main/java/RadarSptrans/example/RadarSPT/config/WebConfig.java
+++ b/src/main/java/RadarSptrans/example/RadarSPT/config/WebConfig.java
@@ -1,16 +1,25 @@
 package RadarSptrans.example.RadarSPT.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
+    private final String[] allowedOrigins;
+
+    public WebConfig(@Value("${sptrans.cors.allowed-origins:http://localhost:5500,http://127.0.0.1:5500}")
+                     String allowedOriginsProperty) {
+        this.allowedOrigins = StringUtils.tokenizeToStringArray(allowedOriginsProperty, ",");
+    }
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://127.0.0.1:5500")
+                .allowedOrigins(allowedOrigins)
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 spring.application.name=RadarSPT
 sptrans.api.token=0b2b7996a6aae16fba7fd5386b3c630d5efc26cb0f9373e1e21aebe89ca60963
+sptrans.cors.allowed-origins=http://localhost:5500,http://127.0.0.1:5500

--- a/src/test/java/RadarSptrans/example/RadarSPT/config/WebConfigTest.java
+++ b/src/test/java/RadarSptrans/example/RadarSPT/config/WebConfigTest.java
@@ -1,0 +1,47 @@
+package RadarSptrans.example.RadarSPT.config;
+
+import RadarSptrans.example.RadarSPT.domain.port.in.BuscarPosicaoPorCodigoUseCase;
+import RadarSptrans.example.RadarSPT.domain.port.in.BuscarPosicaoPorTermoUseCase;
+import RadarSptrans.example.RadarSPT.infrastructure.adapter.in.rest.SpTransController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = SpTransController.class)
+@Import(WebConfig.class)
+@TestPropertySource(properties = "sptrans.cors.allowed-origins=https://example.com,https://another.com")
+class WebConfigTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private BuscarPosicaoPorTermoUseCase buscarPosicaoPorTermoUseCase;
+
+    @MockBean
+    private BuscarPosicaoPorCodigoUseCase buscarPosicaoPorCodigoUseCase;
+
+    @Test
+    void shouldAllowCorsForAllConfiguredOrigins() throws Exception {
+        mockMvc.perform(options("/api/sptrans/buscar")
+                        .header(HttpHeaders.ORIGIN, "https://example.com")
+                        .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET"))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "https://example.com"));
+
+        mockMvc.perform(options("/api/sptrans/buscar")
+                        .header(HttpHeaders.ORIGIN, "https://another.com")
+                        .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET"))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "https://another.com"));
+    }
+}


### PR DESCRIPTION
## Summary
- load CORS allowed origins from the new `sptrans.cors.allowed-origins` property with a sensible localhost default
- document how to override the allowed origins for different environments and cover the behavior with a WebMvc MockMvc test

## Testing
- mvn -q test

------
https://chatgpt.com/codex/tasks/task_e_68dd624ea1cc832792af5a604caee673