### PR TITLE
Ensure SPTrans auth response is closed after use

### DIFF
--- a/src/main/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/out/sptrans/SpTransAuthClientAdapter.java
+++ b/src/main/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/out/sptrans/SpTransAuthClientAdapter.java
@@ -24,14 +24,15 @@ public class SpTransAuthClientAdapter implements AutenticacaoPort {
 
     @Override
     public String autenticar() {
-        Response authResponse = authClient.autenticar(apiToken);
-        if (authResponse.status() == HttpStatus.OK.value()) {
-            Collection<String> cookies = authResponse.headers().get("Set-Cookie");
-            if (cookies != null && !cookies.isEmpty()) {
-                return cookies.iterator().next();
+        try (Response authResponse = authClient.autenticar(apiToken)) {
+            if (authResponse.status() == HttpStatus.OK.value()) {
+                Collection<String> cookies = authResponse.headers().get("Set-Cookie");
+                if (cookies != null && !cookies.isEmpty()) {
+                    return cookies.iterator().next();
+                }
+                throw new CookieSessaoNaoEncontradoException();
             }
-            throw new CookieSessaoNaoEncontradoException();
+            throw new AutenticacaoException();
         }
-        throw new AutenticacaoException();
     }
 }

--- a/src/test/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/out/sptrans/SpTransAuthClientAdapterTest.java
+++ b/src/test/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/out/sptrans/SpTransAuthClientAdapterTest.java
@@ -2,19 +2,18 @@ package RadarSptrans.example.RadarSPT.infrastructure.adapter.out.sptrans;
 
 import RadarSptrans.example.RadarSPT.domain.exception.AutenticacaoException;
 import RadarSptrans.example.RadarSPT.domain.exception.CookieSessaoNaoEncontradoException;
-import feign.Request;
 import feign.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class SpTransAuthClientAdapterTest {
@@ -30,43 +29,37 @@ class SpTransAuthClientAdapterTest {
 
     @Test
     void deveRetornarCookieQuandoAutenticacaoSucesso() {
-        Response response = criarResposta(200, Map.of("Set-Cookie", List.of("cookie=valor")));
+        Response response = mock(Response.class);
+        when(response.status()).thenReturn(200);
+        when(response.headers()).thenReturn(Map.of("Set-Cookie", List.of("cookie=valor")));
         when(authClient.autenticar("token")).thenReturn(response);
 
         String cookie = adapter.autenticar();
 
         assertEquals("cookie=valor", cookie);
+        verify(response).close();
     }
 
     @Test
     void deveLancarExcecaoQuandoCookieNaoEncontrado() {
-        Response response = criarResposta(200, Map.of());
+        Response response = mock(Response.class);
+        when(response.status()).thenReturn(200);
+        when(response.headers()).thenReturn(Collections.emptyMap());
         when(authClient.autenticar("token")).thenReturn(response);
 
         CookieSessaoNaoEncontradoException exception = assertThrows(CookieSessaoNaoEncontradoException.class, adapter::autenticar);
         assertEquals("Cookie de sessão não encontrado na resposta de autenticação.", exception.getMessage());
+        verify(response).close();
     }
 
     @Test
     void deveLancarExcecaoDeAutenticacaoQuandoStatusNaoSucesso() {
-        Response response = criarResposta(401, Map.of());
+        Response response = mock(Response.class);
+        when(response.status()).thenReturn(401);
         when(authClient.autenticar("token")).thenReturn(response);
 
         AutenticacaoException exception = assertThrows(AutenticacaoException.class, adapter::autenticar);
         assertEquals("Falha ao autenticar com o serviço SPTrans.", exception.getMessage());
-    }
-
-    private Response criarResposta(int status, Map<String, Collection<String>> headers) {
-        Request request = Request.create(Request.HttpMethod.POST,
-                "https://api.olhovivo.sptrans.com.br/v2.1/Login/Autenticar",
-                Map.of(),
-                null,
-                StandardCharsets.UTF_8,
-                null);
-        return Response.builder()
-                .status(status)
-                .headers(headers)
-                .request(request)
-                .build();
+        verify(response).close();
     }
 }

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
## Summary
- wrap the SPTrans authentication client call in a try-with-resources block to guarantee the response is closed
- update the adapter tests to mock the Response, verify it is closed, and configure Mockito for final class mocking

## Testing
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68dd66a34ee08327b6d10d6be73967fe