### PR TITLE
Handle SPTrans auth responses without cookies

### DIFF
--- a/src/main/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/out/sptrans/SpTransAuthClientAdapter.java
+++ b/src/main/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/out/sptrans/SpTransAuthClientAdapter.java
@@ -27,16 +27,21 @@ public class SpTransAuthClientAdapter implements AutenticacaoPort {
     @Override
     public String autenticar() {
         Response authResponse = authClient.autenticar(apiToken);
-        if (authResponse.status() == HttpStatus.OK.value()) {
-            Collection<String> cookies = authResponse.headers().get("Set-Cookie");
-            if (cookies != null && !cookies.isEmpty()) {
-                String rawCookie = cookies.iterator().next();
-                String sanitizedCookie = CookieSanitizer.sanitize(rawCookie);
-                if (!sanitizedCookie.isEmpty()) {
-                    return sanitizedCookie;
+        try {
+            if (authResponse.status() == HttpStatus.OK.value()) {
+                Collection<String> cookies = authResponse.headers().get("Set-Cookie");
+                if (cookies != null && !cookies.isEmpty()) {
+                    String rawCookie = cookies.iterator().next();
+                    String sanitizedCookie = CookieSanitizer.sanitize(rawCookie);
+                    if (!sanitizedCookie.isEmpty()) {
+                        return sanitizedCookie;
+                    }
                 }
+                throw new CookieSessaoNaoEncontradoException();
             }
             throw new AutenticacaoException();
+        } finally {
+            authResponse.close();
         }
     }
 

--- a/src/test/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/out/sptrans/SpTransAuthClientAdapterTest.java
+++ b/src/test/java/RadarSptrans/example/RadarSPT/infrastructure/adapter/out/sptrans/SpTransAuthClientAdapterTest.java
@@ -3,11 +3,11 @@ package RadarSptrans.example.RadarSPT.infrastructure.adapter.out.sptrans;
 import RadarSptrans.example.RadarSPT.domain.exception.AutenticacaoException;
 import RadarSptrans.example.RadarSPT.domain.exception.CookieSessaoNaoEncontradoException;
 import RadarSptrans.example.RadarSPT.domain.model.LinhaResponse;
-import feign.Request;
 import feign.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -96,16 +96,9 @@ class SpTransAuthClientAdapterTest {
     }
 
     private Response criarResposta(int status, Map<String, Collection<String>> headers) {
-        Request request = Request.create(Request.HttpMethod.POST,
-                "https://api.olhovivo.sptrans.com.br/v2.1/Login/Autenticar",
-                Map.of(),
-                null,
-                StandardCharsets.UTF_8,
-                null);
-        return Response.builder()
-                .status(status)
-                .headers(headers)
-                .request(request)
-                .build();
+        Response response = mock(Response.class);
+        when(response.status()).thenReturn(status);
+        when(response.headers()).thenReturn(headers);
+        return response;
     }
 }


### PR DESCRIPTION
## Summary
- ensure the SPTrans authentication adapter always closes the Feign response and throws domain-specific exceptions when cookies are missing or the status is not OK
- update the adapter tests to mock Feign responses so the new behaviour can be asserted safely

## Testing
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68e576816ad88327ad910901885c6238